### PR TITLE
Fixed the cursed blank mii name bug

### DIFF
--- a/Mii.py
+++ b/Mii.py
@@ -56,6 +56,7 @@ class Mii(KaitaiStruct):
         self._io.align_to_byte()
         self.mii_name = self._io.read_bytes(20).decode(u"utf-16be")
         self.mii_name, _, _ = self.mii_name.partition('\x00')
+        self.mii_name = self.mii_name.strip()
         self.body_height = self._io.read_u1()
         self.body_weight = self._io.read_u1()
         self.avatar_id = [None] * (4)
@@ -131,6 +132,8 @@ class Mii(KaitaiStruct):
         mii_name = UtilityFunctions.process_name(self.mii_name)
         mii_name = mii_name if len(mii_name) > 0 else '\u200b'
         fc = self.FC if len(self.FC) > 0 else '\u200b'
+        #print(f"Mii name: '{mii_name}'\nLen: {len(mii_name)}")
+        #print(ord(mii_name))
         embed.add_field(name="**Mii Name**",value=mii_name)
         embed.add_field(name="**Gender**",value=f"{'Female' if self.gender else 'Male'}")
         


### PR DESCRIPTION
## Description
<!-- What is this pull request for? What issues does it address (if applicable)? -->
People can somehow make their miis have this name: 　
(Yes, there is something there ^ copy and paste it into a unicode character viewer)
Discord throws an error when embeds values have "blank" strings. Discord considers this character to be blank. For this specific character, `.strip()` strips this character, which allows us to catch this problem before sending it off to Discord.

However, if people find other characters that they can input for their miis that bypass `.strip()` but that Discord considers to be blank, this bug will resurface. If this is possible (which I'm not sure it is), I don't see a great solution other than tackling them as they come.

## Classification
<!-- Put an `x` for things that apply to this PR -->

- [x] Code changes have been tested
- [ ] This PR fixes an issue
- [ ] This PR is not a code change (ie. documentation, typehinting, comments, etc.)