### PR TITLE
Added /fulledit

### DIFF
--- a/BadWolfBot.py
+++ b/BadWolfBot.py
@@ -67,6 +67,7 @@ SUBSTITUTE_TERMS = {"sub", "substitute"}
 PLAYER_PENALTY_TERMS = {"pen", "penalty"}
 TEAM_PENALTY_TERMS = {"teampen", "teampenalty", "tagpen", "tagpenalty"}
 EDIT_PLAYER_SCORE_TERMS = {"edit"}
+EDIT_FULL_GP_TERMS = {"fulledit", "editgp", "editall", "gpedit"}
 PLAYER_DISCONNECT_TERMS = {"dc", "dcs"}
 MERGE_ROOM_TERMS = {"mr", "mergeroom"}
 SET_TABLE_NAME_TERMS = {"setwarname", "settablename"}
@@ -785,6 +786,9 @@ class BadWolfBot(ext_commands.Bot):
         
         elif main_command in EDIT_PLAYER_SCORE_TERMS:
             await commands.TablingCommands.change_player_score_command(message, this_bot, args, server_prefix, is_lounge_server)
+
+        elif main_command in EDIT_FULL_GP_TERMS:
+            await commands.TablingCommands.change_all_player_score_command(message, this_bot, args, server_prefix, is_lounge_server)
         
         elif main_command in PLAYER_PENALTY_TERMS:
             # if False:

--- a/commands.py
+++ b/commands.py
@@ -1882,6 +1882,38 @@ class TablingCommands:
         this_bot.getWar().addEdit(player_fc, gp_num, amount)
         await message.channel.send(f"{player_name} GP{gp_num} score edited to {amount} points.")
 
+    @staticmethod
+    async def change_all_player_score_command(message:discord.Message, this_bot:ChannelBot, args:List[str], server_prefix:str, is_lounge_server:bool):
+        command_name = args[0]
+        if len(args) == 1:
+            to_send = this_bot.getRoom().get_sorted_player_list_string()
+            to_send += f"\n**To edit everyone's GP 2, please enter the Players' score in the order they appear in the list above:** *{server_prefix}{command_name} 2 10 33 32 35 14 32 29 30 22 25 16 14*" # yes this adds to 292
+            await message.channel.send(to_send)
+            return
+
+        if len(args) != len(this_bot.getRoom().get_sorted_player_list())+2:
+            await message.channel.send(example_help(server_prefix, command_name))
+            return
+
+        try:
+            gp_num, scores_arg = int(args[1]), [int(gp_score) for gp_score in args[2:]]
+        except:
+            await message.channel.send(f"GP Number and GP scores must all be numbers. {example_help(server_prefix, command_name)}")
+            return
+
+        table_gps = this_bot.getWar().numberOfGPs
+        if gp_num < 1 or gp_num > table_gps:
+            await message.channel.send(f"The current table is only set to {table_gps} GPs. Your GP number was: {gp_num}")
+            return
+
+        players = this_bot.getRoom().get_sorted_player_list()
+        for x in range(0, len(scores_arg)):
+            player_fc, mii_name = players[x]
+            this_bot.getWar().addEdit(player_fc, gp_num, scores_arg[x])
+
+        this_bot.add_save_state(message.content)
+        await message.channel.send(f"Edited all players' scores for GP{gp_num}")
+        
     #Code is quite similar to chane_player_tag_command, potential refactor opportunity?
     @staticmethod
     async def change_player_name_command(message:discord.Message, this_bot:ChannelBot, args:List[str], server_prefix:str, is_lounge_server:bool):

--- a/common.py
+++ b/common.py
@@ -252,7 +252,7 @@ embed_page_time = timedelta(minutes=2)
 base_url_lorenzi = "https://gb.hlorenzi.com/table.png?data="
 base_url_edit_table_lorenzi = "https://gb.hlorenzi.com/table?data="
 
-BAD_WOLF_ID = 706120725882470460 
+BAD_WOLF_ID = 683193773055934474
 CW_ID = 366774710186278914
 ANDREW_ID = 267395889423712258
 


### PR DESCRIPTION
## Description
<!-- What is this pull request for? What issues does it address (if applicable)? -->
Adds fulledit, which allows you to edit everyone's score for a GP. 
Syntax: /fulledit GP_Number *Everyone's scores in order of `this_bot.getRoom().get_sorted_player_list_string()`*
Example: /fulledit 2 10 33 32 35 14 32 29 30 22 25 16 14

I believe that this is the best option, Bad Wolf also suggested this as the best option. It allows people in Lounge to not get muted for mentioning the bot to edit a gp. It is also helpful for large errors in the table, such as blank times or a missing player on the table. I was considering allowing to undo each edit per player, but I believe it is better (and easier :P) to undo all the changes in one command, in case you badly mess up the command.

## Checklist
<!-- Put an `x` for things that apply to this PR -->

- [X] If code changes were made, they have been tested
- [ ] This PR fixes an issue 
- [ ] This PR is not a code change (ie. documentation, typehinting, comments, etc.)