### PR TITLE
New command for past miis

### DIFF
--- a/BadWolfBot.py
+++ b/BadWolfBot.py
@@ -108,7 +108,7 @@ LOUNGE_NAME_TERMS = {"lounge", "loungename", "ln"}
 GET_FLAG_TERMS = {"getflag", "gf"}
 SET_FLAG_TERMS = {"setflag", "sf"}
 MII_TERMS = {"mii"}
-PAST_MII_TERMS = {"pastmii", "oldmii", "previousmii"}
+PREVIOUS_MII_TERMS = {"pastmii", "oldmii", "previousmii"}
 WORLDWIDE_TERMS = {"wws", "ww", "rtww", "rtwws", "worldwide", "worldwides"}
 CTWW_TERMS = {"ctgpww", "ctgpwws", "ctwws", "ctww", "ctww", "ctwws", "ctworldwide", "ctworldwides", "customtrackworldwide", "customtrackworldwides"}
 BATTLES_TERMS = {"battle", "battles", "btww", "btwws", "battleww", "battlewws", "battleworldwide", "battleworldwides"}
@@ -868,6 +868,9 @@ class BadWolfBot(ext_commands.Bot):
         
         elif main_command in MII_TERMS:
             await commands.OtherCommands.mii_command(message, args)
+        
+        elif main_command in PREVIOUS_MII_TERMS:
+            await commands.OtherCommands.previous_mii_command(message, args)
         
         elif main_command in SET_TABLE_NAME_TERMS:
             await commands.TablingCommands.set_table_name_command(message, this_bot, args, server_prefix, is_lounge_server)

--- a/BadWolfBot.py
+++ b/BadWolfBot.py
@@ -108,6 +108,7 @@ LOUNGE_NAME_TERMS = {"lounge", "loungename", "ln"}
 GET_FLAG_TERMS = {"getflag", "gf"}
 SET_FLAG_TERMS = {"setflag", "sf"}
 MII_TERMS = {"mii"}
+PAST_MII_TERMS = {"pastmii", "oldmii", "previousmii"}
 WORLDWIDE_TERMS = {"wws", "ww", "rtww", "rtwws", "worldwide", "worldwides"}
 CTWW_TERMS = {"ctgpww", "ctgpwws", "ctwws", "ctww", "ctww", "ctwws", "ctworldwide", "ctworldwides", "customtrackworldwide", "customtrackworldwides"}
 BATTLES_TERMS = {"battle", "battles", "btww", "btwws", "battleww", "battlewws", "battleworldwide", "battleworldwides"}

--- a/Mii.py
+++ b/Mii.py
@@ -151,6 +151,30 @@ class Mii(KaitaiStruct):
         file = File(self.get_mii_picture_link())
         embed.set_image(url="attachment://" + self.file_name)
         return file, embed
+
+    def get_previous_mii_embed(self, is_ct: bool, date_stamp: str):
+        embed = Embed(
+                    title = f"",
+                    description="",
+                    colour = Mii.mii_color_dict[self.favorite_color]
+                )
+        
+        mii_name = UtilityFunctions.clean_for_output(self.mii_name)
+        mii_name = mii_name if len(mii_name) > 0 else '\u200b'
+        fc = self.FC if len(self.FC) > 0 else '\u200b'
+        #print(f"Mii name: '{mii_name}'\nLen: {len(mii_name)}")
+        #print(ord(mii_name))
+        embed.add_field(name="**Mii Name**",value=mii_name)
+        embed.add_field(name="**Gender**",value=f"{'Female' if self.gender else 'Male'}")
+        
+        embed.add_field(name="**FC**",value=fc)
+        embed.add_field(name="**Date used:**",value=date_stamp)
+        embed.add_field(name="**Used on:**",value="CTs" if is_ct else "RTs")
+        #file_name_id
+        file = File(self.get_mii_picture_link())
+        embed.set_image(url="attachment://" + self.file_name)
+        return file, embed
+
     
     def get_mii_picture_link(self):
         return self.folder_path + self.file_name

--- a/Mii.py
+++ b/Mii.py
@@ -3,6 +3,7 @@ Created on Apr 3, 2021
 
 @author: willg
 '''
+from datetime import date
 from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
 from discord import Embed, File
 import UtilityFunctions
@@ -11,7 +12,7 @@ import cv2
 import UserDataProcessing
 import numpy as np
 import common
-
+import humanize
 
 class Mii(KaitaiStruct):
 
@@ -153,8 +154,15 @@ class Mii(KaitaiStruct):
         return file, embed
 
     def get_previous_mii_embed(self, is_ct: bool, date_stamp: str):
+        try:
+            year, month, day = date_stamp.split()[0].split("-")
+            month_text = date(day=int(day), month=int(month), year=int(year)).strftime('%B')
+            date_stamp = f"{month_text} {humanize.ordinal(day)}, {year}"
+        except:
+            pass
+        
         embed = Embed(
-                    title = f"",
+                    title = date_stamp,
                     description="",
                     colour = Mii.mii_color_dict[self.favorite_color]
                 )
@@ -166,10 +174,11 @@ class Mii(KaitaiStruct):
         #print(ord(mii_name))
         embed.add_field(name="**Mii Name**",value=mii_name)
         embed.add_field(name="**Gender**",value=f"{'Female' if self.gender else 'Male'}")
-        
         embed.add_field(name="**FC**",value=fc)
-        embed.add_field(name="**Date used:**",value=date_stamp)
+        
+        #embed.add_field(name="**Date used:**",value=date_stamp)
         embed.add_field(name="**Used on:**",value="CTs" if is_ct else "RTs")
+        embed.add_field(name="**Region:**",value="Unknown" if self.country_code is None else self.country_code)
         #file_name_id
         file = File(self.get_mii_picture_link())
         embed.set_image(url="attachment://" + self.file_name)

--- a/MiiPuller.py
+++ b/MiiPuller.py
@@ -210,6 +210,11 @@ async def get_mii_data_for_pids(pids:Dict[int, str]) -> str:
         mii_puller_session = aiohttp.ClientSession()
         return None
 
+def mii_hex_to_binary(mii_hex: str):
+    return binascii.unhexlify(mii_hex)
+            
+
+
 async def get_mii_data_for_fcs(fcs:Set[str]):
     if len(fcs) == 0:
         return {}
@@ -233,6 +238,14 @@ def get_mii_file_names(fc, message_id):
     cache_download_path = mii_cache_folder_path + cache_file_name
     full_download_path = folder_path + real_file_name
     return cache_download_path, full_download_path, folder_path, real_file_name
+
+async def get_one_time_mii(mii_hex_str: str, fc: str, message_id: int, picture_width=512):
+    _, full_download_path, folder_path, real_file_name = get_mii_file_names(fc, message_id)
+    success = await miirender.download_mii(mii_hex_str, full_download_path, picture_width=picture_width)
+    if success is None:
+        return MII_DOWNLOAD_FAILURE_ERROR_MESSAGE
+    if success:
+        return Mii.Mii(mii_hex_to_binary(mii_hex_str), mii_hex_str, folder_path, real_file_name, fc)
 
 async def download_mii_photo(fc, mii_hex_str, message_id, picture_width=512):
     cache_download_path, full_download_path, _, _ = get_mii_file_names(fc, message_id)
@@ -308,6 +321,8 @@ if __name__ == "__main__":
     #sake_response = format_sake_xml_response(sake_response)
     #print("Formatted...")
     #print(type(sake_response))
+
+    
     result_1 = common.run_async_function_no_loop(get_miis(["4086-2278-0250"], "1234566"))
     print(result_1)
     common.run_async_function_no_loop(asyncio.sleep(5))

--- a/commands.py
+++ b/commands.py
@@ -993,9 +993,8 @@ class OtherCommands:
         matching_races = {data[1]:data for data in mii_hexes if data[-1] == selected_mii_hex}
         selected_race = random.choice(list(matching_races))
         selected_data = matching_races[selected_race]
-        print(selected_data)
         #Obtain mii picture for the selected mii
-        event_id, rxx, match_time, fc, mii_hex = selected_data
+        _, _, match_time, is_ct, fc, mii_hex = selected_data
         common.client.mii_cooldowns[message.author.id] = time.monotonic()
         mii = await MiiPuller.get_one_time_mii(mii_hex, fc, message.id)
 
@@ -1004,8 +1003,8 @@ class OtherCommands:
             return
 
         try:
-            file, embed = mii.get_previous_mii_embed(True, match_time)
-            embed.title = f"{SmartTypes.possessive(SmartTypes.capitalize(descriptive))} previous mii"
+            file, embed = mii.get_previous_mii_embed(is_ct, match_time)
+            embed.title = f"{SmartTypes.possessive(SmartTypes.capitalize(descriptive))} mii from {embed.title}"
             await message.channel.send(file=file, embed=embed)
         finally:
             mii.clean_up()

--- a/commands.py
+++ b/commands.py
@@ -978,12 +978,14 @@ class OtherCommands:
         smart_type = SmartTypes.SmartLookupTypes(to_load, allowed_types=SmartTypes.SmartLookupTypes.PLAYER_LOOKUP_TYPES)
         await smart_type.lounge_api_update()
         fcs = smart_type.get_fcs()
-        # common.client.mii_cooldowns[message.author.id] = time.monotonic()
 
         descriptive, pronoun = smart_type.get_clean_smart_print(message)
         if fcs is None:
             await message.channel.send(f"Could not find any FCs for {descriptive}, have {pronoun} verified an FC in Lounge?")
             return
+        
+        #Update cooldown
+        common.client.mii_cooldowns[message.author.id] = time.monotonic()
 
         mii_hexes = await DataTracker.DataRetriever.get_mii_hexes(fcs)
         #First, to select a unique mii randomly with equal probability, we'll create a set of all of their mii hexes
@@ -995,7 +997,6 @@ class OtherCommands:
         selected_data = matching_races[selected_race]
         #Obtain mii picture for the selected mii
         _, _, match_time, is_ct, fc, mii_hex = selected_data
-        common.client.mii_cooldowns[message.author.id] = time.monotonic()
         mii = await MiiPuller.get_one_time_mii(mii_hex, fc, message.id)
 
         if isinstance(mii, str):

--- a/data_tracking/DataTracker.py
+++ b/data_tracking/DataTracker.py
@@ -91,6 +91,15 @@ class DataRetriever(object):
         return await db_connection.execute("SELECT track_name, url, fixed_track_name, is_ct, track_name_lookup "
                                            "FROM Track")
 
+    @staticmethod
+    async def get_mii_hexes(fcs: List[str]):
+        """Returns the event id, first race id in the event, first match time of the event, fc,
+        and mii hex of the mii used in the event for each that one of the given fcs was in.
+        IMPORTANT NUANCED INFORMATION: See get_fc_mii_hexes_query for returned data in special cases"""
+        mii_hex_query = QB.SQL_Search_Query_Builder.get_fc_mii_hexes_query(fcs)
+        return await db_connection.execute(mii_hex_query, fcs)
+    
+
 class ChannelBotSQLDataValidator(object):
     def wrong_type_message(self, data, expected_type, multi=False):
         if multi:

--- a/data_tracking/Data_Tracker_SQL_Query_Builder.py
+++ b/data_tracking/Data_Tracker_SQL_Query_Builder.py
@@ -326,17 +326,18 @@ class SQL_Search_Query_Builder(object):
             ORDER BY Event_Races.event_id) x
         ON Event_FCs.event_id = x.event_id
         WHERE mii_hex IS NOT NULL AND (fc = "4086-2278-0250" OR fc = "1079-7432-6162")
-        ORDER BY Event_FCs.event_id; 
+        ORDER BY Event_FCs.event_id;
         """
 
 
         return f"""
-        SELECT Event_Races.event_id, MIN(Race.race_id) as race_id, Race.match_time, x.fc, x.mii_hex
+        SELECT Event_Races.event_id, MIN(Race.race_id) as race_id, Race.match_time, Track.is_ct, x.fc, x.mii_hex
         FROM Event_Races INNER JOIN 
                 (SELECT Event_FCs.event_id, fc, mii_hex
                 FROM Event_FCs
                 WHERE mii_hex IS NOT NULL AND fc IN {build_sql_args_list(fcs)}) x ON x.event_id = Event_Races.event_id
             INNER JOIN Race ON Event_Races.race_id = Race.race_id
+            INNER JOIN Track ON Race.track_name = Track.track_name
         GROUP BY Event_Races.event_id
         ORDER BY Event_Races.event_id;"""
         

--- a/data_tracking/Data_Tracker_SQL_Query_Builder.py
+++ b/data_tracking/Data_Tracker_SQL_Query_Builder.py
@@ -2,6 +2,9 @@
 Created on Oct 29, 2021
 @author: willg
 '''
+from typing import List
+
+
 PLAYER_TABLE_NAMES = ["fc", "pid", "player_url"]
 RACE_TABLE_NAMES = ["race_id", "rxx", "time_added", "match_time", "race_number", "room_name", "track_name", "room_type", "cc", "region", "is_wiimmfi_race", "num_players", "first_place_time", "last_place_time", "avg_time"]
 TRACK_TABLE_NAMES = ["track_name", "url", "fixed_track_name", "is_ct", "track_name_lookup"]
@@ -309,6 +312,36 @@ class SQL_Search_Query_Builder(object):
         """
 
     @staticmethod
+    def get_fc_mii_hexes_query(fcs: List[str]):
+        """The query returned will include different events that included the sane first race. Meaning, you
+        may get duplicate races if they were tabled in multiple tables.
+        Another important nuance: if more than one of the fcs given were in a race, only one race for that FC is given back.
+        This function is only meant to be called for one distinct player, not multiple players, so the query is optimized under this
+        assumption. If you want a query that will return races and hexes for multiple players, use this:
+        SELECT Event_FCs.event_id, fc, mii_hex, x.match_time
+        FROM Event_FCs INNER JOIN (SELECT Event_Races.event_id, min(Race.race_id) as race_id, Race.match_time
+            FROM Event_Races INNER JOIN Race
+            ON Event_Races.race_id = Race.race_id
+            GROUP BY Event_Races.event_id
+            ORDER BY Event_Races.event_id) x
+        ON Event_FCs.event_id = x.event_id
+        WHERE mii_hex IS NOT NULL AND (fc = "4086-2278-0250" OR fc = "1079-7432-6162")
+        ORDER BY Event_FCs.event_id; 
+        """
+
+
+        return f"""
+        SELECT Event_Races.event_id, MIN(Race.race_id) as race_id, Race.match_time, x.fc, x.mii_hex
+        FROM Event_Races INNER JOIN 
+                (SELECT Event_FCs.event_id, fc, mii_hex
+                FROM Event_FCs
+                WHERE mii_hex IS NOT NULL AND fc IN {build_sql_args_list(fcs)}) x ON x.event_id = Event_Races.event_id
+            INNER JOIN Race ON Event_Races.race_id = Race.race_id
+        GROUP BY Event_Races.event_id
+        ORDER BY Event_Races.event_id;"""
+        
+
+    @staticmethod
     def get_player_races(did, days):
         days_filter_clause = f"AND Event.time_added > date('now','-{days} days')" if (days is not None) else ""
 
@@ -337,5 +370,3 @@ class SQL_Search_Query_Builder(object):
         JOIN ({SQL_Search_Query_Builder.get_player_races(opponent_did, days)}) as b 
         ON a.race_id = b.race_id
         """
-
-

--- a/slash_cogs/MiscSlashCommands.py
+++ b/slash_cogs/MiscSlashCommands.py
@@ -263,6 +263,20 @@ class MiscSlash(ext_commands.Cog):
         if player: args.append(player)
         
         await commands.OtherCommands.mii_command(message, args)
+
+    @slash_command(name='pastmii',
+    description="Get a random previous mii of a Lounge player",
+    guild_ids=GUILDS)
+    async def _past_mii(
+        self,
+        ctx: discord.ApplicationContext,
+        player: Option(str, PLAYER_ARG_DESCRIPTION, required=False, default=None)
+    ):
+        command, message, _, _, _ = await self.bot.slash_interaction_pre_invoke(ctx)
+        args = [command]
+        if player: args.append(player)
+        
+        await commands.OtherCommands.previous_mii_command(message, args)
     
     @slash_command(name="loungename",
     description="Get a player's Lounge name",


### PR DESCRIPTION
## Description
<!-- What is this pull request for? What issues does it address (if applicable)? -->
This PR adds a new command to Table Bot, the previous mii command, which displays a random mii from the past that a player has used.

- [x] Slash command interface implemented
- [x] Text command interface implemented
- [x] Core code of command written

## Checklist
<!-- Put an `x` for things that apply to this PR -->

- [x] If code changes were made, they have been tested
- [ ] This PR fixes an issue
- [ ] This PR is not a code change (ie. documentation, typehinting, comments, etc.)