### PR TITLE
Prediction links have been changed from fields to descriptions in the embed.

### DIFF
--- a/Lounge.py
+++ b/Lounge.py
@@ -12,6 +12,8 @@ from collections import namedtuple
 
 MKW_LOUNGE_RT_UPDATE_PREVIEW_LINK = "https://www.mkwlounge.gg/ladder/tabler.php?ladder_type=rt&event_data="
 MKW_LOUNGE_CT_UPDATE_PREVIEW_LINK = "https://www.mkwlounge.gg/ladder/tabler.php?ladder_type=ct&event_data="
+MKW_LOUNGE_RT_UPDATER_LINK = MKW_LOUNGE_RT_UPDATE_PREVIEW_LINK
+MKW_LOUNGE_CT_UPDATER_LINK = MKW_LOUNGE_CT_UPDATE_PREVIEW_LINK
 MKW_LOUNGE_RT_UPDATER_CHANNEL = 758161201682841610
 MKW_LOUNGE_CT_UPDATER_CHANNEL = 758161224202059847
 
@@ -19,9 +21,11 @@ UpdateChannels = namedtuple(
     "UpdateChannels",
     [
         "updater_channel_id_primary",
+        "updater_link_primary",
         "preview_link_primary",
         "type_text_primary",
         "updater_channel_id_secondary",
+        "updater_link_secondary",
         "preview_link_secondary",
         "type_text_secondary",
     ],
@@ -30,17 +34,21 @@ UpdateChannels = namedtuple(
 lounge_channel_mappings = {
     common.MKW_LOUNGE_SERVER_ID: UpdateChannels(
         updater_channel_id_primary=MKW_LOUNGE_RT_UPDATER_CHANNEL,
+        updater_link_primary=MKW_LOUNGE_RT_UPDATER_LINK,
         preview_link_primary=MKW_LOUNGE_RT_UPDATE_PREVIEW_LINK,
         type_text_primary="RT",
         updater_channel_id_secondary=MKW_LOUNGE_CT_UPDATER_CHANNEL,
+        updater_link_secondary=MKW_LOUNGE_CT_UPDATER_LINK,
         preview_link_secondary=MKW_LOUNGE_CT_UPDATE_PREVIEW_LINK,
         type_text_secondary="CT",
     ),
     common.TABLE_BOT_DISCORD_SERVER_ID: UpdateChannels(
         updater_channel_id_primary=common.TABLE_BOT_SERVER_BETA_TWO_CHANNEL_ID,
+        updater_link_primary=MKW_LOUNGE_RT_UPDATER_LINK,
         preview_link_primary=MKW_LOUNGE_RT_UPDATE_PREVIEW_LINK,
         type_text_primary="RT",
         updater_channel_id_secondary=common.TABLE_BOT_SERVER_BETA_TWO_CHANNEL_ID,
+        updater_link_secondary=MKW_LOUNGE_CT_UPDATER_LINK,
         preview_link_secondary=MKW_LOUNGE_CT_UPDATE_PREVIEW_LINK,
         type_text_secondary="CT",
     ),
@@ -169,6 +177,7 @@ class Lounge:
     def get_primary_information(self):
         return (
             self.channels_mapping.updater_channel_id_primary,
+            self.channels_mapping.updater_link_primary,
             self.channels_mapping.preview_link_primary,
             self.channels_mapping.type_text_primary,
         )
@@ -176,6 +185,7 @@ class Lounge:
     def get_secondary_information(self):
         return (
             self.channels_mapping.updater_channel_id_secondary,
+            self.channels_mapping.updater_link_secondary,
             self.channels_mapping.preview_link_secondary,
             self.channels_mapping.type_text_secondary,
         )

--- a/Lounge.py
+++ b/Lounge.py
@@ -12,8 +12,6 @@ from collections import namedtuple
 
 MKW_LOUNGE_RT_UPDATE_PREVIEW_LINK = "https://www.mkwlounge.gg/ladder/tabler.php?ladder_type=rt&event_data="
 MKW_LOUNGE_CT_UPDATE_PREVIEW_LINK = "https://www.mkwlounge.gg/ladder/tabler.php?ladder_type=ct&event_data="
-MKW_LOUNGE_RT_UPDATER_LINK = MKW_LOUNGE_RT_UPDATE_PREVIEW_LINK
-MKW_LOUNGE_CT_UPDATER_LINK = MKW_LOUNGE_CT_UPDATE_PREVIEW_LINK
 MKW_LOUNGE_RT_UPDATER_CHANNEL = 758161201682841610
 MKW_LOUNGE_CT_UPDATER_CHANNEL = 758161224202059847
 
@@ -21,11 +19,9 @@ UpdateChannels = namedtuple(
     "UpdateChannels",
     [
         "updater_channel_id_primary",
-        "updater_link_primary",
         "preview_link_primary",
         "type_text_primary",
         "updater_channel_id_secondary",
-        "updater_link_secondary",
         "preview_link_secondary",
         "type_text_secondary",
     ],
@@ -34,21 +30,17 @@ UpdateChannels = namedtuple(
 lounge_channel_mappings = {
     common.MKW_LOUNGE_SERVER_ID: UpdateChannels(
         updater_channel_id_primary=MKW_LOUNGE_RT_UPDATER_CHANNEL,
-        updater_link_primary=MKW_LOUNGE_RT_UPDATER_LINK,
         preview_link_primary=MKW_LOUNGE_RT_UPDATE_PREVIEW_LINK,
         type_text_primary="RT",
         updater_channel_id_secondary=MKW_LOUNGE_CT_UPDATER_CHANNEL,
-        updater_link_secondary=MKW_LOUNGE_CT_UPDATER_LINK,
         preview_link_secondary=MKW_LOUNGE_CT_UPDATE_PREVIEW_LINK,
         type_text_secondary="CT",
     ),
     common.TABLE_BOT_DISCORD_SERVER_ID: UpdateChannels(
         updater_channel_id_primary=common.TABLE_BOT_SERVER_BETA_TWO_CHANNEL_ID,
-        updater_link_primary=MKW_LOUNGE_RT_UPDATER_LINK,
         preview_link_primary=MKW_LOUNGE_RT_UPDATE_PREVIEW_LINK,
         type_text_primary="RT",
         updater_channel_id_secondary=common.TABLE_BOT_SERVER_BETA_TWO_CHANNEL_ID,
-        updater_link_secondary=MKW_LOUNGE_CT_UPDATER_LINK,
         preview_link_secondary=MKW_LOUNGE_CT_UPDATE_PREVIEW_LINK,
         type_text_secondary="CT",
     ),
@@ -177,7 +169,6 @@ class Lounge:
     def get_primary_information(self):
         return (
             self.channels_mapping.updater_channel_id_primary,
-            self.channels_mapping.updater_link_primary,
             self.channels_mapping.preview_link_primary,
             self.channels_mapping.type_text_primary,
         )
@@ -185,7 +176,6 @@ class Lounge:
     def get_secondary_information(self):
         return (
             self.channels_mapping.updater_channel_id_secondary,
-            self.channels_mapping.updater_link_secondary,
             self.channels_mapping.preview_link_secondary,
             self.channels_mapping.type_text_secondary,
         )

--- a/commands.py
+++ b/commands.py
@@ -1312,7 +1312,7 @@ class LoungeCommands:
 
                 embed = discord.Embed(
                                     title = "",
-                                    description=f"[Click to preview this update]({updater_link})",
+                                    description=f"[Click to preview this update]({preview_link})",
                                     colour = discord.Colour.dark_red()
                                 )
                 file = discord.File(table_image_path)
@@ -1326,8 +1326,6 @@ class LoungeCommands:
                 embed.add_field(name='Submitted from', value=message.channel.mention)
                 embed.add_field(name='Submitted by', value=message.author.mention)
                 embed.add_field(name='Discord ID', value=str(message.author.id))
-                embed.add_field(name='Preview Link', value=str(f"[Preview]({preview_link})"))
-
                 embed.set_image(url="attachment://" + table_image_path)
                 embed.set_author(name="Updater Automation", icon_url="https://64.media.tumblr.com/b0df9696b2c8388dba41ad9724db69a4/tumblr_mh1nebDwp31rsjd4ho1_500.jpg")
 
@@ -1342,11 +1340,11 @@ class LoungeCommands:
                 file = discord.File(table_image_path)
                 embed = discord.Embed(
                                     title=f"Successfully submitted to {type_text} Reporters and {type_text} Updaters",
+                                    description=f"[Click to preview this update]({preview_link})",
                                     colour=discord.Colour.green()
                                 )
                 embed.add_field(name='Submission ID', value=str(id_to_submit))
                 embed.add_field(name='Races Played', value=str(races_played))
-                embed.add_field(name='Preview Link', value=str(f"[Preview]({preview_link})"))
                 embed.set_image(url="attachment://" + table_image_path)
                 embed.set_author(name="Updater Automation", icon_url="https://64.media.tumblr.com/b0df9696b2c8388dba41ad9724db69a4/tumblr_mh1nebDwp31rsjd4ho1_500.jpg")
                 embed.set_footer(text="Note: the actual update may look different than this preview if the Updaters need to first update previous mogis. If the link is too long, just hit the enter key.")
@@ -1724,9 +1722,10 @@ class TablingCommands:
 
         preview_link += urllib.parse.quote(json_data)
 
-        embedVar = discord.Embed(title="Prediction Link",url=preview_link,colour=discord.Color.blue())
+        embedVar = discord.Embed(colour=discord.Color.blue())
         embedVar.set_author(
             name='MMR/LR Prediction',
+            description=f"[Click to preview this update]({preview_link})",
             icon_url='https://www.mkwlounge.gg/images/logo.png'
         )
         await message.channel.send(embed=embedVar)

--- a/commands.py
+++ b/commands.py
@@ -1218,7 +1218,7 @@ class LoungeCommands:
     async def _mogi_update(client, message: discord.Message, this_bot: TableBot.ChannelBot, args: List[str], lounge_server_updates: Lounge.Lounge, is_primary=True):
         command_incorrect_format_message = "The format of this command is: `?" + args[0] + " TierNumber RacesPlayed (TableText)`\n- **TierNumber** must be a number. For RTs, between 1 and 8. For CTs, between 1 and 7. If you are trying to submit a squadqueue table, **TierNumber** should be: squadqueue\n-**RacesPlayed** must be a number, between 1 and 32."
         cooldown = lounge_server_updates.get_user_update_submit_cooldown(message.author.id)
-        updater_channel_id, updater_link, preview_link, type_text = lounge_server_updates.get_information(is_primary)
+        updater_channel_id, _, preview_link, type_text = lounge_server_updates.get_information(is_primary)
 
         if cooldown > 0:
             await message.channel.send(f"You have already submitted a table very recently. Please wait {cooldown} more seconds before submitting another table.", delete_after=10)
@@ -1304,7 +1304,6 @@ class LoungeCommands:
 
                 updater_channel = client.get_channel(updater_channel_id)
                 preview_link += urllib.parse.quote(json_data)
-                updater_link += urllib.parse.quote(json_data)
 
 
                 embed = discord.Embed(
@@ -1709,7 +1708,7 @@ class TablingCommands:
         rt_ct, tier = rt_ct or 'rt', tier or 1
         is_primary = rt_ct == 'rt'
 
-        updater_channel_id, updater_link, preview_link, type_text = lounge_server_updates.get_information(is_primary)
+        updater_channel_id, _, preview_link, type_text = lounge_server_updates.get_information(is_primary)
         error_code, newTableText, json_data = await MogiUpdate.textInputUpdate(table_text, str(tier), this_bot.war.numberOfGPs*4, is_rt=is_primary)
 
         if error_code != MogiUpdate.SUCCESS_EC:

--- a/commands.py
+++ b/commands.py
@@ -1218,7 +1218,7 @@ class LoungeCommands:
     async def _mogi_update(client, message: discord.Message, this_bot: TableBot.ChannelBot, args: List[str], lounge_server_updates: Lounge.Lounge, is_primary=True):
         command_incorrect_format_message = "The format of this command is: `?" + args[0] + " TierNumber RacesPlayed (TableText)`\n- **TierNumber** must be a number. For RTs, between 1 and 8. For CTs, between 1 and 7. If you are trying to submit a squadqueue table, **TierNumber** should be: squadqueue\n-**RacesPlayed** must be a number, between 1 and 32."
         cooldown = lounge_server_updates.get_user_update_submit_cooldown(message.author.id)
-        updater_channel_id, preview_link, type_text = lounge_server_updates.get_information(is_primary)
+        updater_channel_id, updater_link, preview_link, type_text = lounge_server_updates.get_information(is_primary)
 
         if cooldown > 0:
             await message.channel.send(f"You have already submitted a table very recently. Please wait {cooldown} more seconds before submitting another table.", delete_after=10)
@@ -1304,6 +1304,7 @@ class LoungeCommands:
 
                 updater_channel = client.get_channel(updater_channel_id)
                 preview_link += urllib.parse.quote(json_data)
+                updater_link += urllib.parse.quote(json_data)
 
 
                 embed = discord.Embed(
@@ -1708,7 +1709,7 @@ class TablingCommands:
         rt_ct, tier = rt_ct or 'rt', tier or 1
         is_primary = rt_ct == 'rt'
 
-        updater_channel_id, preview_link, type_text = lounge_server_updates.get_information(is_primary)
+        updater_channel_id, updater_link, preview_link, type_text = lounge_server_updates.get_information(is_primary)
         error_code, newTableText, json_data = await MogiUpdate.textInputUpdate(table_text, str(tier), this_bot.war.numberOfGPs*4, is_rt=is_primary)
 
         if error_code != MogiUpdate.SUCCESS_EC:

--- a/commands.py
+++ b/commands.py
@@ -1218,7 +1218,7 @@ class LoungeCommands:
     async def _mogi_update(client, message: discord.Message, this_bot: TableBot.ChannelBot, args: List[str], lounge_server_updates: Lounge.Lounge, is_primary=True):
         command_incorrect_format_message = "The format of this command is: `?" + args[0] + " TierNumber RacesPlayed (TableText)`\n- **TierNumber** must be a number. For RTs, between 1 and 8. For CTs, between 1 and 7. If you are trying to submit a squadqueue table, **TierNumber** should be: squadqueue\n-**RacesPlayed** must be a number, between 1 and 32."
         cooldown = lounge_server_updates.get_user_update_submit_cooldown(message.author.id)
-        updater_channel_id, updater_link, preview_link, type_text = lounge_server_updates.get_information(is_primary)
+        updater_channel_id, preview_link, type_text = lounge_server_updates.get_information(is_primary)
 
         if cooldown > 0:
             await message.channel.send(f"You have already submitted a table very recently. Please wait {cooldown} more seconds before submitting another table.", delete_after=10)
@@ -1304,7 +1304,6 @@ class LoungeCommands:
 
                 updater_channel = client.get_channel(updater_channel_id)
                 preview_link += urllib.parse.quote(json_data)
-                updater_link += urllib.parse.quote(json_data)
 
 
                 embed = discord.Embed(
@@ -1709,7 +1708,7 @@ class TablingCommands:
         rt_ct, tier = rt_ct or 'rt', tier or 1
         is_primary = rt_ct == 'rt'
 
-        updater_channel_id, updater_link, preview_link, type_text = lounge_server_updates.get_information(is_primary)
+        updater_channel_id, preview_link, type_text = lounge_server_updates.get_information(is_primary)
         error_code, newTableText, json_data = await MogiUpdate.textInputUpdate(table_text, str(tier), this_bot.war.numberOfGPs*4, is_rt=is_primary)
 
         if error_code != MogiUpdate.SUCCESS_EC:
@@ -1722,7 +1721,7 @@ class TablingCommands:
         embedVar = discord.Embed(colour=discord.Color.blue())
         embedVar.set_author(
             name='MMR/LR Prediction',
-            description=f"[Click to preview this update]({preview_link})",
+            description=f"[Preview Link]({preview_link})",
             icon_url='https://www.mkwlounge.gg/images/logo.png'
         )
         await message.channel.send(embed=embedVar)


### PR DESCRIPTION
## Description
<!-- What is this pull request for? What issues does it address (if applicable)? -->
Prediction links have been changed from fields to descriptions in the embed. (Unable to test due to not being able to emulate lounge API requests)
## Checklist
<!-- Put an `x` for things that apply to this PR -->

- [ ] If code changes were made, they have been tested
- [x] This PR fixes an issue
- [ ] This PR is not a code change (ie. documentation, typehinting, comments, etc.)