### PR TITLE
gpcount command

### DIFF
--- a/BadWolfBot.py
+++ b/BadWolfBot.py
@@ -88,6 +88,7 @@ RACE_ORDER_TERMS = {'raceorder', 'changeraces', 'changeraceorder', 'racesorder',
 TABLE_THEME_TERMS = {'style', 'theme', 'tablestyle', 'tabletheme'}
 GRAPH_TERMS = {'graph', 'tablegraph', 'graphtheme'}
 DISPLAY_GP_SIZE_TERMS = {'size', 'tablesize', 'displaysize'}
+GP_COUNT_TERMS = {"gpcount", "changegpcount"}
 
 
 #Commands that require a table to be started, but don't modify the war/room/table in any way
@@ -184,7 +185,7 @@ SET_API_URL_TERMS = {"apiurl", "setapiurl", "api_url", "set_api_url"}
 
 
 
-needPermissionCommands = DISPLAY_GP_SIZE_TERMS | TABLE_THEME_TERMS | GRAPH_TERMS | RESET_TERMS | START_WAR_TERMS | UNDO_TERMS | REDO_TERMS | LIST_REDOS_TERMS | LIST_UNDOS_TERMS | REMOVE_RACE_TERMS | PLAYER_PENALTY_TERMS | TEAM_PENALTY_TERMS | EDIT_PLAYER_SCORE_TERMS | PLAYER_DISCONNECT_TERMS | MERGE_ROOM_TERMS | SET_TABLE_NAME_TERMS | CHANGE_PLAYER_NAME_TERMS | CHANGE_PLAYER_TAG_TERMS | CHANGE_ROOM_SIZE_TERMS | EARLY_DC_TERMS | QUICK_EDIT_TERMS | SUBSTITUTE_TERMS | GET_SUBSTITUTIONS_TERMS | INTERACTIONS
+needPermissionCommands = DISPLAY_GP_SIZE_TERMS | GP_COUNT_TERMS | TABLE_THEME_TERMS | GRAPH_TERMS | RESET_TERMS | START_WAR_TERMS | UNDO_TERMS | REDO_TERMS | LIST_REDOS_TERMS | LIST_UNDOS_TERMS | REMOVE_RACE_TERMS | PLAYER_PENALTY_TERMS | TEAM_PENALTY_TERMS | EDIT_PLAYER_SCORE_TERMS | PLAYER_DISCONNECT_TERMS | MERGE_ROOM_TERMS | SET_TABLE_NAME_TERMS | CHANGE_PLAYER_NAME_TERMS | CHANGE_PLAYER_TAG_TERMS | CHANGE_ROOM_SIZE_TERMS | EARLY_DC_TERMS | QUICK_EDIT_TERMS | SUBSTITUTE_TERMS | GET_SUBSTITUTIONS_TERMS | INTERACTIONS
 ALLOWED_COMMANDS_IN_LOUNGE_ECHELONS = LOUNGE_MOGI_UPDATE_TERMS | STATS_TERMS | INVITE_TERMS | MII_TERMS | FC_TERMS | BATTLES_TERMS | CTWW_TERMS | WORLDWIDE_TERMS | VERIFY_ROOM_TERMS | SET_FLAG_TERMS | GET_FLAG_TERMS | POPULAR_TRACKS_TERMS | UNPOPULAR_TRACKS_TERMS | TOP_PLAYERS_TERMS | BEST_TRACK_TERMS | WORST_TRACK_TERMS | RECORD_TERMS
 
 common.needPermissionCommands.update(needPermissionCommands)
@@ -1022,6 +1023,9 @@ class BadWolfBot(ext_commands.Bot):
 
         elif main_command in DISPLAY_GP_SIZE_TERMS:
             await commands.TablingCommands.gp_display_size_command(message, this_bot, args, server_prefix, is_lounge_server)
+
+        elif main_command in GP_COUNT_TERMS:
+            await commands.TablingCommands.gp_count_command(message, this_bot, args, server_prefix, is_lounge_server)
             
         elif main_command in POPULAR_TRACKS_TERMS:
             await commands.StatisticCommands.popular_tracks_command(message, args, server_prefix, is_top_tracks=True)

--- a/BadWolfBot.py
+++ b/BadWolfBot.py
@@ -87,7 +87,7 @@ RACE_ORDER_TERMS = {'raceorder', 'changeraces', 'changeraceorder', 'racesorder',
 
 TABLE_THEME_TERMS = {'style', 'theme', 'tablestyle', 'tabletheme'}
 GRAPH_TERMS = {'graph', 'tablegraph', 'graphtheme'}
-DISPLAY_GP_SIZE_TERMS = {'size', 'tablesize', 'displaysize'}
+DISPLAY_GP_SIZE_TERMS = {'gpsize', 'size', 'tablesize', 'displaysize'}
 GP_COUNT_TERMS = {"gpcount", "changegpcount"}
 
 

--- a/War.py
+++ b/War.py
@@ -193,6 +193,9 @@ class War(object):
     def addTeamPenalty(self, team_tag, amount):
         self.teamPenalties[team_tag] += amount
     
+    def set_number_of_gps(self, new_gp_count):
+        self.numberOfGPs = new_gp_count
+
     def __str__(self):
         war_string = "-- WAR --"
         war_string += "\nNumber of teams: " + str(self.numberOfTeams)

--- a/commands.py
+++ b/commands.py
@@ -2806,6 +2806,40 @@ class TablingCommands:
             this_bot.add_save_state(message.content)
             this_bot.set_race_size(new_size)
             await message.channel.send(f"Each section of the table will now be {new_size} races.")
+            
+    @staticmethod
+    async def gp_count_command(message:discord.Message, this_bot:ChannelBot, args:List[str], server_prefix:str, is_lounge_server:bool):
+        ensure_table_loaded_check(this_bot, server_prefix, is_lounge_server)
+
+        COUNT_ARG_NAME = "<gp_count>"
+
+        if len(args) != 2:
+            await message.channel.send(f"Here's how to use this command: `{server_prefix}{args[0]} {COUNT_ARG_NAME}`")
+            return
+        
+        new_gp_count = args[1]
+
+        if not new_gp_count.isnumeric() or int(new_gp_count) <= 0:
+            await message.channel.send(f"Invalid argument `{COUNT_ARG_NAME}` (`{new_gp_count}`). Argument must be a positive number.")
+            return
+        
+        new_gp_count = int(new_gp_count)
+        war = this_bot.get_war()
+
+        if new_gp_count == war.get_number_of_gps():
+            await message.channel.send(f"Number of GPs is already set to `{new_gp_count}`.")
+            return
+        
+        played_gps = this_bot.get_room().getNumberOfGPS()
+
+        if new_gp_count < played_gps:
+            await message.channel.send(f"Too many races have been played. `{COUNT_ARG_NAME}` must be at least `{played_gps}`.")
+            return
+
+        war.set_number_of_gps(new_gp_count)
+
+        await message.channel.send(f"GP count was successfully updated to `{new_gp_count}`.")
+        await TablingCommands.war_picture_command(message, this_bot, ['wp'], server_prefix, is_lounge_server)
 
     @staticmethod
     async def race_edit_command(message: discord.Message, this_bot: ChannelBot, args: List[str], is_lounge_server: bool):

--- a/commands.py
+++ b/commands.py
@@ -2819,7 +2819,7 @@ class TablingCommands:
         
         new_gp_count = args[1]
 
-        if not new_gp_count.isnumeric() or int(new_gp_count) <= 0:
+        if not UtilityFunctions.isint(new_gp_count) or int(new_gp_count) <= 0:
             await message.channel.send(f"Invalid argument `{COUNT_ARG_NAME}` (`{new_gp_count}`). Argument must be a positive number.")
             return
         
@@ -2828,12 +2828,6 @@ class TablingCommands:
 
         if new_gp_count == war.get_number_of_gps():
             await message.channel.send(f"Number of GPs is already set to `{new_gp_count}`.")
-            return
-        
-        played_gps = this_bot.get_room().getNumberOfGPS()
-
-        if new_gp_count < played_gps:
-            await message.channel.send(f"Too many races have been played. `{COUNT_ARG_NAME}` must be at least `{played_gps}`.")
             return
 
         war.set_number_of_gps(new_gp_count)

--- a/slash_cogs/TablingSlashCommands.py
+++ b/slash_cogs/TablingSlashCommands.py
@@ -263,6 +263,19 @@ class Table_Slash(ext_commands.Cog):
         args = [command, str(race)]
         
         await self.bot.process_message_commands(message, args, this_bot, server_prefix, is_lounge, from_slash=True)
+        
+    @slash_command(name="gpcount",
+    description="Changes the number of GPs in a table",
+    guild_ids=common.SLASH_GUILDS)
+    async def _gp_count(
+        self,
+        ctx: discord.ApplicationContext,
+        gp_count: Option(int, "The number of GPs")
+    ):
+        command, message, this_bot, server_prefix, is_lounge = await self.bot.slash_interaction_pre_invoke(ctx)
+        args = [command, str(gp_count)]
+        
+        await self.bot.process_message_commands(message, args, this_bot, server_prefix, is_lounge, from_slash=True)
 
     @slash_command(name="changename",
     description="Change a player's name",


### PR DESCRIPTION
## Description
Adds a gpcount command, which allows a user to change the number of gps after a war has been started. Have tested with offline testing rooms, but not on live rooms from Wiimmfi.

## Checklist
- [x] If code changes were made, they have been tested
- [ ] This PR fixes an issue
- [ ] This PR is not a code change (ie. documentation, typehinting, comments, etc.)