### PR TITLE
T0 option for update RT

### DIFF
--- a/slash_cogs/LoungeSlashCommands.py
+++ b/slash_cogs/LoungeSlashCommands.py
@@ -127,6 +127,7 @@ class LoungeSlash(ext_commands.Cog):
         self, 
         ctx: discord.ApplicationContext,
         tier: Option(str, "Tier of event", choices=[
+            OptionChoice('T0', '0'), 
             OptionChoice('T1', '1'), 
             OptionChoice('T2', '2'), 
             OptionChoice('T3', '3'), 


### PR DESCRIPTION
## Description
Adds T0 option for /update RT command, as requested [here](https://discord.com/channels/387347467332485122/1071908779358162984/1367909134200082594).

I have tested to make sure that the T0 option is available, but I haven't tested anything more than that.

## Checklist
- [x] If code changes were made, they have been tested
- [ ] This PR fixes an issue
- [ ] This PR is not a code change (ie. documentation, typehinting, comments, etc.)