### PR TITLE
fix /vr refresh bug

### DIFF
--- a/Components.py
+++ b/Components.py
@@ -8,7 +8,7 @@ import TimerDebuggers
 import common
 import Stats
 import time
-from typing import Dict, Union
+from typing import Dict, List, Union
 # import gc
 
 class ManualTeamsModal(discord.ui.Modal):
@@ -339,17 +339,17 @@ class UpdateVRButton(discord.ui.Button['VRView']):
         self.responded = True
         await interaction.response.edit_message(content='Refreshing room...')
         # await interaction.response.defer()
-        msg = InteractionUtils.create_proxy_msg(interaction, self.view.trigger_command_args)
         # Stats.log_command('vr')
 
-        data = await commands.OtherCommands.vr_command(msg, self.bot, self.view.trigger_command_args, self_refresh=True)
+        data = await commands.OtherCommands.vr_command(self.view.trigger_message, self.bot, self.view.trigger_command_args, self_refresh=True)
         
         await self.view.refresh_vr(interaction, data)
 
 class VRView(discord.ui.View):
-    def __init__(self, trigger_command_args, bot: TableBot.ChannelBot):
+    def __init__(self, trigger_message: discord.Message, trigger_command_args: List[str], bot: TableBot.ChannelBot):
         super().__init__(timeout=300)
         self.bot = bot
+        self.trigger_message = trigger_message
         self.trigger_command_args = trigger_command_args
         self.message_ref: Union[discord.Message, discord.InteractionMessage] = None
         self.last_vr_content = None

--- a/commands.py
+++ b/commands.py
@@ -1154,7 +1154,7 @@ class OtherCommands:
             return {'content': f"{str_msg}```"}
         else:
             # await message2.delete()
-            vr_view = Components.VRView(args, this_bot)
+            vr_view = Components.VRView(message, args, this_bot)
             this_bot.add_component(vr_view)
             await vr_view.edit(message2, content=f"{str_msg}```")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ kaitaistruct
 matplotlib
 bitstring
 tabulate
+aiohttp<=3.9.5
 aiosqlite
 lxml
 certifi


### PR DESCRIPTION
fixes #220

as a result of this change, the data of the original command message is stored in the vr view, which means that vr refreshes will use the data of the original command initiator.

requirements.txt was updated to limit aiohttp to a version before a breaking change (see https://github.com/aio-libs/aiohttp/issues/8555):
![image](https://github.com/user-attachments/assets/1595149f-e5e1-4aae-8012-f061dc79dc31)

this code is unfortunately untested, because /vring requires access to wiimmfi itself. if it turns out this code doesn't work, or you have any suggestions as to how i could test this, please let me know.